### PR TITLE
add option to poll stats for all nodes in the cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ make
 ./elasticsearch_exporter --help
 ```
 
-* __`es.server`:__ Address (host and port) of the Elasticsearch node we should
+* __`es.uri`:__ Address (host and port) of the Elasticsearch node we should
     connect to. This could be a local node (`localhost:8500`, for instance), or
     the address of a remote Elasticsearch server.
-* __`es.cluster_nodes`:__ If true, query stats for all nodes in the cluster,
+* __`es.all`:__ If true, query stats for all nodes in the cluster,
     rather than just the node we connect to.
+* __`es.timeout`:__ Timeout for trying to get stats from Elasticsearch. (ex: 20s)
 * __`web.listen-address`:__ Address to listen on for web interface and telemetry.
 * __`web.telemetry-path`:__ Path under which to expose metrics.
 

--- a/elasticsearch_exporter.go
+++ b/elasticsearch_exporter.go
@@ -506,10 +506,15 @@ func main() {
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		esUri         = flag.String("es.uri", "http://localhost:9200", "HTTP API address of a Elasticsearch node.")
 		esTimeout     = flag.Duration("es.timeout", 5*time.Second, "Timeout for trying to get stats from Elasticsearch.")
+		esAllNodes    = flag.Bool("es.all", false, "Export stats for all nodes in the cluster.")
 	)
 	flag.Parse()
 
-	*esUri = *esUri + "/_nodes/_local/stats"
+	if *esAllNodes {
+		*esUri = *esUri + "/_nodes/stats"
+	} else {
+		*esUri = *esUri + "/_nodes/_local/stats"
+	}
 
 	exporter := NewExporter(*esUri, *esTimeout)
 	prometheus.MustRegister(exporter)


### PR DESCRIPTION
Tested on a 6 node cluster (1 master, 5 data nodes).  Might cause timeouts on very large clusters.

    $ time curl -s "http://localhost:9200/_nodes/_local/stats" &> /dev/null
    real	0m0.011s
    user	0m0.000s
    sys	0m0.004s

    $ time curl -s "http://localhost:9200/_nodes/stats" &> /dev/null
    real	0m2.164s
    user	0m0.008s
    sys	0m0.004s
