### PR TITLE
specify expected json fields within indices response

### DIFF
--- a/elasticsearch_exporter.go
+++ b/elasticsearch_exporter.go
@@ -111,15 +111,15 @@ type NodeStatsTCPResponse struct {
 }
 
 type NodeStatsIndicesResponse struct {
-	Docs        NodeStatsIndicesDocsResponse
-	Store       NodeStatsIndicesStoreResponse
-	Indexing    NodeStatsIndicesIndexingResponse
-	Get         NodeStatsIndicesGetResponse
-	Search      NodeStatsIndicesSearchResponse
-	FieldData   NodeStatsIndicesFieldDataResponse
-	FilterCache NodeStatsIndicesFieldDataResponse
-	Flush       NodeStatsIndicesFlushResponse
-	Segments    NodeStatsIndicesSegmentsResponse
+	Docs        NodeStatsIndicesDocsResponse      `json:"docs"`
+	Store       NodeStatsIndicesStoreResponse     `json:"store"`
+	Indexing    NodeStatsIndicesIndexingResponse  `json:"indexing"`
+	Get         NodeStatsIndicesGetResponse       `json:"get"`
+	Search      NodeStatsIndicesSearchResponse    `json:"search"`
+	FieldData   NodeStatsIndicesFieldDataResponse `json:"fielddata"`
+	FilterCache NodeStatsIndicesFieldDataResponse `json:"filter_cache"`
+	Flush       NodeStatsIndicesFlushResponse     `json:"flush"`
+	Segments    NodeStatsIndicesSegmentsResponse  `json:"segments"`
 }
 
 type NodeStatsIndicesDocsResponse struct {


### PR DESCRIPTION
filter_cache/* was returning 0 in the exporter without an explicit field mapping, updated other fields for consistency.